### PR TITLE
feat: add Renovate configuration file

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,35 @@
+{
+  extends: [
+    "config:recommended",
+    ":semanticCommits",
+    ":rebaseStalePrs",
+    ":labels(dependencies)",
+  ],
+
+  timezone: "Asia/Tokyo",
+  automergeStrategy: "merge-commit",
+  prCreation: "immediate",
+  automerge: false,
+
+  packageRules: [
+    {
+      matchUpdateTypes: ["minor", "patch"],
+      automerge: true,
+      automergeType: "pr",
+      requiredStatusChecks: null
+    },
+    {
+      matchUpdateTypes: ["major"],
+      automerge: false,
+      labels: ["major-update"],
+      reviewers: ["44smkn"]
+    }
+  ],
+
+  prHeader: "🤖 Renovate dependency update",
+
+  lockFileMaintenance: {
+    enabled: true,
+    schedule: ["before 6am on monday"]
+  }
+}


### PR DESCRIPTION
This pull request introduces a new `renovate.json5` configuration file to manage dependency updates using Renovate. The configuration sets up recommended defaults, automerge rules, labeling, and scheduling for dependency updates.

Dependency update automation configuration:

* Added `renovate.json5` with recommended base configuration, semantic commit messages, and dependency labeling.
* Configured timezone, automerge strategy, immediate PR creation, and disabled global automerge.
* Defined package rules to automerge minor/patch updates and require manual review for major updates, with special labeling and reviewer assignment.
* Customized PR headers and enabled scheduled lock file maintenance.